### PR TITLE
feat: support for personal repository urls

### DIFF
--- a/stash/repository.js
+++ b/stash/repository.js
@@ -1,7 +1,12 @@
 var url = require('url');
 
+var SLASH_SLUG = '\\/([a-z0-9_\\-~.]+)'
+var REGEXP_PROJECT_DATA = new RegExp('^\\/(projects|scm)' + SLASH_SLUG, 'i')
+var REGEXP_REPO_DATA    = new RegExp(SLASH_SLUG + '(\\.git)?$', 'i')
+var REGEXP_SSH_FORMAT   = new RegExp('^' + SLASH_SLUG + SLASH_SLUG + '\\.git$', 'i')
+
 function getProjectData(_repositoryUrl) {
-    var project = _repositoryUrl.match(/^\/(projects|scm)\/([a-z0-9_\-]+)/i);
+    var project = _repositoryUrl.match(REGEXP_PROJECT_DATA)
     if (project !== null) {
         return {
             path: '/projects/' + project[2],
@@ -11,7 +16,7 @@ function getProjectData(_repositoryUrl) {
 }
 
 function getRepositoryData(_repositoryUrl) {
-    var repo = _repositoryUrl.match(/\/([a-z0-9_\-]+)(\.git)?$/i);
+    var repo = _repositoryUrl.match(REGEXP_REPO_DATA)
     if (repo !== null) {
         return {
             path: '/repos/' + repo[1],
@@ -22,7 +27,7 @@ function getRepositoryData(_repositoryUrl) {
 
 function parseRepositoryUrl(_repositoryUrl) {
     var repositoryUrl = url.parse(_repositoryUrl);
-    var sshFormat = repositoryUrl.pathname.match(/^\/([a-z0-9_\-]+)\/([a-z0-9_\-]+)\.git$/i);
+    var sshFormat = repositoryUrl.pathname.match(REGEXP_SSH_FORMAT)
 
     if (sshFormat === null) {
         repositoryUrl.project = getProjectData(repositoryUrl.pathname);

--- a/stash/repository.js
+++ b/stash/repository.js
@@ -18,9 +18,11 @@ function getProjectData(_repositoryUrl) {
 function getRepositoryData(_repositoryUrl) {
     var repo = _repositoryUrl.match(REGEXP_REPO_DATA)
     if (repo !== null) {
+        var repoName = String(repo[1])
+        if (repoName.endsWith('.git')) repoName = repoName.slice(0, -4)
         return {
-            path: '/repos/' + repo[1],
-            name: repo[1]
+            path: '/repos/' + repoName,
+            name: repoName
         };
     }
 }

--- a/test/bootstrap.js
+++ b/test/bootstrap.js
@@ -2,7 +2,6 @@ var chai = require('chai');
 
 chai.use(require('sinon-chai'));
 chai.use(require('chai-http'));
-chai.request.addPromises(Promise);
 chai.config.includeStack = true;
 
 global.expect = chai.expect;

--- a/test/spec/stash/repository.js
+++ b/test/spec/stash/repository.js
@@ -19,7 +19,7 @@ describe('Repository URL parser', function () {
         expect(url).to.have.deep.property('repository.name', 'bar');
         expect(url).to.have.deep.property('repository.path', '/repos/bar');
     });
-    it('should handle /scp/:project/:repo format URL', function () {
+    it('should handle /scm/:project/:repo format URL', function () {
       var url = repository.parseUrl('http://stash.domain.com/scm/npme/ci-demo-stash.git');
 
       expect(url).to.have.deep.property('project.name', 'npme');

--- a/test/spec/stash/repository.js
+++ b/test/spec/stash/repository.js
@@ -28,4 +28,44 @@ describe('Repository URL parser', function () {
       expect(url).to.have.deep.property('repository.name', 'ci-demo-stash');
       expect(url).to.have.deep.property('repository.path', '/repos/ci-demo-stash');
     })
+
+    it('should handle personal repo url in ssh format', function () {
+      var url = repository.parseUrl('ssh://git@hostname.compute.cloud.com:7999/~andrew.goode/hello-world.git')
+
+      expect(url).to.have.deep.property('project.name', '~andrew.goode')
+      expect(url).to.have.deep.property('project.path', '/projects/~andrew.goode')
+
+      expect(url).to.have.deep.property('repository.name', 'hello-world')
+      expect(url).to.have.deep.property('repository.path', '/repos/hello-world')
+    })
+
+    it('should handle personal repo url in http format', function () {
+      var url = repository.parseUrl('http://andrew.goode@hostname.compute.cloud.com/scm/~andrew.goode/hello-world.git')
+
+      expect(url).to.have.deep.property('project.name', '~andrew.goode')
+      expect(url).to.have.deep.property('project.path', '/projects/~andrew.goode')
+
+      expect(url).to.have.deep.property('repository.name', 'hello-world')
+      expect(url).to.have.deep.property('repository.path', '/repos/hello-world')
+    })
+
+    it('should handle url in http format without .git', function () {
+      var url = repository.parseUrl('http://andrew.goode@hostname.compute.cloud.com/scm/~andrew.goode/hello-world')
+
+      expect(url).to.have.deep.property('project.name', '~andrew.goode')
+      expect(url).to.have.deep.property('project.path', '/projects/~andrew.goode')
+
+      expect(url).to.have.deep.property('repository.name', 'hello-world')
+      expect(url).to.have.deep.property('repository.path', '/repos/hello-world')
+    })
+
+    it('should handle dot in repo name', function () {
+      var url = repository.parseUrl('ssh://git@hostname.compute.cloud.com:7999/~andrew.goode/one.two.git')
+
+      expect(url).to.have.deep.property('project.name', '~andrew.goode')
+      expect(url).to.have.deep.property('project.path', '/projects/~andrew.goode')
+
+      expect(url).to.have.deep.property('repository.name', 'one.two')
+      expect(url).to.have.deep.property('repository.path', '/repos/one.two')
+    })
 });


### PR DESCRIPTION
[Personal repos](https://developer.atlassian.com/static/rest/bitbucket-server/4.12.1/bitbucket-rest.html#personal-repositories) have a URL format like

```
ssh://git@example.com:7999/~${username}/${reponame}.git
```

or

```
http://${username}@example.com/scm/~${username}/${reponame}.git
```

And both usernames and repo names may have a dot (`.`) in the name.

This PR changes the repository URL parsing logic to accept tildes and dots to support these formats.

Note that the existing project-centric API also works with personal repos, treating the `~${username}` like the project slug, so the current API client did not require any changes when checking authorization against a personal repo.

Publishing packages with these auth plugin changes has been tested in a real Bitbucket Server environment.