### PR TITLE
feat: support website login

### DIFF
--- a/authenticator.js
+++ b/authenticator.js
@@ -13,18 +13,19 @@ function Authenticator() {
 Authenticator.prototype.authenticate = function (_credentials, _cb) {
     var self = this;
     var credentials = _credentials.body;
-    var user = this.client.user(credentials.name, credentials.password);
 
     if (!credentials) {
-        _cb(new Error('Missing credentials'));
+        return _cb(new Error('Missing credentials'));
     }
 
+    var user = this.client.user(credentials.name, credentials.password);
+
     try {
-        user.authorize(credentials.name, credentials.password).then(function (_stashData) {
+        user.authorize().then(function (_stashData) {
             if (!_stashData) {
                 return _cb(new Error('Invalid StashUser object'));
             }
-            if (_stashData.user.email.toLowerCase() !== credentials.email.toLowerCase()) {
+            if (credentials.email && _stashData.user.email.toLowerCase() !== credentials.email.toLowerCase()) {
                 return _cb(new Error('Invalid StashUser email'));
             }
 

--- a/test/spec/authenticator.js
+++ b/test/spec/authenticator.js
@@ -31,4 +31,17 @@ describe('authenticator', function () {
             done();
         });
     });
+
+    it('works for website login (missing email in body)', function (done) {
+      authenticator.authenticate({
+        body: {
+          name: 'bob',
+          password: 'bob'
+        }
+      }, function (error, data) {
+        expect(error).to.be.null
+        expect(data).to.have.property('token', '3dbfc51334ccb878384ce927abd00068d47bde68cce14f5171ddc22b7897b95e')
+        done()
+      })
+    })
 });


### PR DESCRIPTION
If **Auth Website** is enabled, credentials in an authentication request will not contain an email address. This PR refactors the logic to bypass the email check if email is not given in credentials.

Successfully tested in a real Bitbucket Server environment.